### PR TITLE
Distinguish volume privilege grants

### DIFF
--- a/migrate_permissions.py
+++ b/migrate_permissions.py
@@ -86,6 +86,7 @@ privileges = [
 # COMMAND ----------
 
 grant_cmds = []
+volume_grant_cmds = []
 
 # Retrieve tables in the destination catalog to check which tables were cloned
 dest_tables_query = f"""
@@ -105,17 +106,34 @@ except Exception:
 for p in privileges:
     if p["type"] == "TABLE" and f"{p['schema']}.{p['name']}" not in dest_tables:
         continue
+
     object_identifier = f"{destination_catalog}.{p['schema']}.{p['name']}"
-    grant_cmds.append(
-        f"GRANT {p['privilege']} ON {object_identifier} TO `{p['principal']}`;"
-    )
+
+    if p["type"] == "VOLUME":
+        volume_grant_cmds.append(
+            f"GRANT {p['privilege']} ON VOLUME {object_identifier} TO `{p['principal']}`;"
+        )
+    else:
+        grant_cmds.append(
+            f"GRANT {p['privilege']} ON {object_identifier} TO `{p['principal']}`;"
+        )
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Display Commands
+# MAGIC ## Display GRANT Commands (Non-Volume)
 
 # COMMAND ----------
 
 for cmd in grant_cmds:
+    print(cmd)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Display GRANT Commands for Volumes
+
+# COMMAND ----------
+
+for cmd in volume_grant_cmds:
     print(cmd)


### PR DESCRIPTION
## Summary
- split volume privilege logic into its own collection
- show grants for volumes separately so they can run in their own cell

## Testing
- `python -m py_compile migrate_permissions.py move_volumes.py clone_catalog.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687145254cfc8329a70ae27c11596374