### PR TITLE
Add function migration notebook

### DIFF
--- a/migrate_functions.ipynb
+++ b/migrate_functions.ipynb
@@ -1,0 +1,91 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "06e528eb",
+   "metadata": {},
+   "source": [
+    "# Migrate Functions to a New Catalog\n",
+    "This notebook reads all user-defined functions from a source catalog and generates SQL commands to recreate them in a destination catalog. Specify the catalog names below and run all cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c8b48d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Configure source and destination catalogs\n",
+    "try:\n",
+    "    dbutils.widgets.text(\"1.source_catalog\", \"source_catalog\")\n",
+    "    dbutils.widgets.text(\"2.destination_catalog\", \"destination_catalog\")\n",
+    "    source_catalog = dbutils.widgets.get(\"1.source_catalog\")\n",
+    "    destination_catalog = dbutils.widgets.get(\"2.destination_catalog\")\n",
+    "except NameError:\n",
+    "    # When running as a standard Python script (e.g., for testing), define values here\n",
+    "    source_catalog = \"source_catalog\"\n",
+    "    destination_catalog = \"destination_catalog\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e03bfd64",
+   "metadata": {},
+   "source": [
+    "## Read Functions From the Source Catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f550f5d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "functions = []\n",
+    "schemas_df = spark.sql(f\"SHOW SCHEMAS IN {source_catalog}\")\n",
+    "for row in schemas_df.collect():\n",
+    "    schema = row[0]\n",
+    "    funcs_df = spark.sql(f\"SHOW USER FUNCTIONS IN {source_catalog}.{schema}\")\n",
+    "    for f in funcs_df.collect():\n",
+    "        func_name = f[0]\n",
+    "        create_stmt_df = spark.sql(f\"SHOW CREATE FUNCTION {source_catalog}.{schema}.{func_name}\")\n",
+    "        create_stmt = create_stmt_df.collect()[0][0]\n",
+    "        dest_stmt = create_stmt.replace(f'{source_catalog}.{schema}', f'{destination_catalog}.{schema}')\n",
+    "        functions.append(dest_stmt)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb1c9355",
+   "metadata": {},
+   "source": [
+    "## Display CREATE FUNCTION Commands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9f8b573",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "for cmd in functions:\n",
+    "    print(cmd)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "environmentMetadata": {
+    "environment_version": "3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `migrate_functions.ipynb` for migrating UDFs between catalogs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875783c38b483298d447ae8f81ef31c