### PR TITLE
Add catalog deletion notebook

### DIFF
--- a/erase_old_catalog.ipynb
+++ b/erase_old_catalog.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ca6e3d98",
+   "metadata": {},
+   "source": [
+    "# Erase Old Catalog\n",
+    "This notebook drops all user-defined functions, tables, and views from a catalog and then removes the schemas. Provide the catalog name with the widget below and run all cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47dcd5a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "dbutils.widgets.text(\"1.catalog\", \"old_catalog\")\n",
+    "\n",
+    "catalog = dbutils.widgets.get(\"1.catalog\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7dc56f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "skip_schemas = {\"information_schema\", \"pg_catalog\"}\n",
+    "\n",
+    "schemas_df = spark.sql(f\"SHOW SCHEMAS IN `{catalog}`\")\n",
+    "\n",
+    "for row in schemas_df.collect():\n",
+    "    schema = row[0]\n",
+    "    if schema.lower() in skip_schemas:\n",
+    "        continue\n",
+    "\n",
+    "    # Drop functions first\n",
+    "    funcs_df = spark.sql(f\"SHOW USER FUNCTIONS IN `{catalog}`.`{schema}`\")\n",
+    "    for f in funcs_df.collect():\n",
+    "        func_name = f[0]\n",
+    "        spark.sql(f\"DROP FUNCTION IF EXISTS `{catalog}`.`{schema}`.`{func_name}`\")\n",
+    "\n",
+    "    # Drop tables and views\n",
+    "    tables_df = spark.sql(f\"SHOW TABLES IN `{catalog}`.`{schema}`\")\n",
+    "    for t in tables_df.collect():\n",
+    "        table_name = t.tableName\n",
+    "        if t.tableType == 'VIEW':\n",
+    "            spark.sql(f\"DROP VIEW IF EXISTS `{catalog}`.`{schema}`.`{table_name}`\")\n",
+    "        else:\n",
+    "            spark.sql(f\"DROP TABLE IF EXISTS `{catalog}`.`{schema}`.`{table_name}`\")\n",
+    "\n",
+    "    # Drop the schema itself\n",
+    "    spark.sql(f\"DROP SCHEMA IF EXISTS `{catalog}`.`{schema}`\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aad5298c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'Catalog `{catalog}` cleanup complete.')"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "environmentMetadata": {
+    "environment_version": "3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `erase_old_catalog.ipynb` to drop all functions, tables, views and schemas for a catalog

## Testing
- `pip install nbformat`

------
https://chatgpt.com/codex/tasks/task_e_6877f14d834083298a810c2de5b575d4