### PR TITLE
Use DiscoverX to parallelize table deletion

### DIFF
--- a/erase_old_catalog.ipynb
+++ b/erase_old_catalog.ipynb
@@ -1,14 +1,26 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "ca6e3d98",
-   "metadata": {},
-   "source": [
-    "# Erase Old Catalog\n",
-    "This notebook drops all user-defined functions, tables, and views from a catalog and then removes the schemas. Provide the catalog name with the widget below and run all cells."
-   ]
-  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "ca6e3d98",
+      "metadata": {},
+      "source": [
+        "# Erase Old Catalog\n",
+        "This notebook drops all user-defined functions, tables, and views from a catalog and then removes the schemas. Provide the catalog name with the widget below and run all cells."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "install-discoverx",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "%pip install dbl-discoverx\n",
+        "dbutils.library.restartPython()\n"
+      ]
+    },
   {
    "cell_type": "code",
    "execution_count": null,
@@ -22,42 +34,49 @@
     "catalog = dbutils.widgets.get(\"1.catalog\")\n"
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e7dc56f6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "skip_schemas = {\"information_schema\", \"pg_catalog\"}\n",
-    "\n",
-    "schemas_df = spark.sql(f\"SHOW SCHEMAS IN `{catalog}`\")\n",
-    "\n",
-    "for row in schemas_df.collect():\n",
-    "    schema = row[0]\n",
-    "    if schema.lower() in skip_schemas:\n",
-    "        continue\n",
-    "\n",
-    "    # Drop functions first\n",
-    "    funcs_df = spark.sql(f\"SHOW USER FUNCTIONS IN `{catalog}`.`{schema}`\")\n",
-    "    for f in funcs_df.collect():\n",
-    "        func_name = f[0]\n",
-    "        spark.sql(f\"DROP FUNCTION IF EXISTS `{catalog}`.`{schema}`.`{func_name}`\")\n",
-    "\n",
-    "    # Drop tables and views\n",
-    "    tables_df = spark.sql(f\"SHOW TABLES IN `{catalog}`.`{schema}`\")\n",
-    "    for t in tables_df.collect():\n",
-    "        table_name = t.tableName\n",
-    "        if t.tableType == 'VIEW':\n",
-    "            spark.sql(f\"DROP VIEW IF EXISTS `{catalog}`.`{schema}`.`{table_name}`\")\n",
-    "        else:\n",
-    "            spark.sql(f\"DROP TABLE IF EXISTS `{catalog}`.`{schema}`.`{table_name}`\")\n",
-    "\n",
-    "    # Drop the schema itself\n",
-    "    spark.sql(f\"DROP SCHEMA IF EXISTS `{catalog}`.`{schema}`\")\n"
-   ]
-  },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e7dc56f6",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "skip_schemas = {\"information_schema\", \"pg_catalog\"}\n",
+        "\n",
+        "from discoverx import DX\n",
+        "\n",
+        "dx = DX()\n",
+        "\n",
+        "schemas_df = spark.sql(f\"SHOW SCHEMAS IN `{catalog}`\")\n",
+        "schemas = [row[0] for row in schemas_df.collect() if row[0].lower() not in skip_schemas]\n",
+        "\n",
+        "# Drop functions sequentially\n",
+        "for schema in schemas:\n",
+        "    funcs_df = spark.sql(f\"SHOW USER FUNCTIONS IN `{catalog}`.`{schema}`\")\n",
+        "    for f in funcs_df.collect():\n",
+        "        func_name = f[0]\n",
+        "        spark.sql(f\"DROP FUNCTION IF EXISTS `{catalog}`.`{schema}`.`{func_name}`\")\n",
+        "\n",
+        "# Drop tables in parallel using DiscoverX\n",
+        "def drop_table(table_info):\n",
+        "    try:\n",
+        "        spark.sql(f\"DROP TABLE IF EXISTS `{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`\")\n",
+        "        return True\n",
+        "    except Exception as err:\n",
+        "        return str(err)\n",
+        "\n",
+        "dx.from_tables(f\"{catalog}.*.*\").map(drop_table)\n",
+        "\n",
+        "# Drop views and schemas sequentially\n",
+        "for schema in schemas:\n",
+        "    tables_df = spark.sql(f\"SHOW TABLES IN `{catalog}`.`{schema}`\")\n",
+        "    for t in tables_df.collect():\n",
+        "        if t.tableType == 'VIEW':\n",
+        "            spark.sql(f\"DROP VIEW IF EXISTS `{catalog}`.`{schema}`.`{t.tableName}`\")\n",
+        "    spark.sql(f\"DROP SCHEMA IF EXISTS `{catalog}`.`{schema}`\")\n"
+      ]
+    },
   {
    "cell_type": "code",
    "execution_count": null,


### PR DESCRIPTION
## Summary
- install `dbl-discoverx` in the catalog deletion notebook
- use DiscoverX to drop tables concurrently
- keep functions and views sequential

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f871ee048329831c98c841dc296b