### PR TITLE
Add restart to change owner install cell

### DIFF
--- a/change_owner.ipynb
+++ b/change_owner.ipynb
@@ -18,7 +18,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install dbl-discoverx"
+    "%pip install dbl-discoverx",
+    "dbutils.library.restartpython\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- ensure `dbutils.library.restartpython` runs after installing `dbl-discoverx`

## Testing
- `grep -n restartpython -n change_owner.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_6878e84fa3a083299490761f2eacc580