### PR TITLE
Fix results printing for DiscoverX notebooks

### DIFF
--- a/change_owner.ipynb
+++ b/change_owner.ipynb
@@ -181,7 +181,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results.display()"
+    "import json\n",
+    "for item in results:\n",
+    "    print(json.dumps(item, indent=4))"
    ]
   }
  ],

--- a/clone_catalog.ipynb
+++ b/clone_catalog.ipynb
@@ -1,140 +1,141 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "308ee9ba",
-      "metadata": {},
-      "source": [
-        "# Clone a Catalog\n",
-        "This notebook uses [DiscoverX](https://github.com/databrickslabs/discoverx) to clone all schemas and tables from a source catalog into a destination catalog using Delta Lake `CLONE`.\n",
-        "\n",
-        "Specify the source and destination catalogs with the widgets below and run all cells.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "5de86c07",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "\n",
-        "%pip install dbl-discoverx\n",
-        "dbutils.library.restartPython()\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4f289880",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "\n",
-        "%md\n",
-        "## Configure source and destination catalogs\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "0371d684",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "\n",
-        "# Create widgets for user input\n",
-        "dbutils.widgets.text(\"1.source_catalog\", \"source_catalog\")\n",
-        "dbutils.widgets.text(\"2.destination_catalog\", \"destination_catalog\")\n",
-        "\n",
-        "source_catalog = dbutils.widgets.get(\"1.source_catalog\")\n",
-        "destination_catalog = dbutils.widgets.get(\"2.destination_catalog\")\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "0c3c753d",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "\n",
-        "%md\n",
-        "## Clone all tables using DiscoverX\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "387c79c0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "\n",
-        "from discoverx import DX\n",
-        "\n",
-        "dx = DX()\n",
-        "\n",
-        "spark.sql(f\"CREATE CATALOG IF NOT EXISTS `{destination_catalog}`\")\n",
-        "\n",
-        "\n",
-        "def clone_table(table_info):\n",
-        "    \"\"\"Clone a single table into the destination catalog.\"\"\"\n",
-        "    spark.sql(f\"CREATE SCHEMA IF NOT EXISTS `{destination_catalog}`.`{table_info.schema}`\")\n",
-        "    try:\n",
-        "        spark.sql(\n",
-        "            f\"\"\"CREATE OR REPLACE TABLE `{destination_catalog}`.`{table_info.schema}`.`{table_info.table}` CLONE `{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`\"\"\"\n",
-        "        )\n",
-        "        return {\n",
-        "            \"source\": f\"`{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
-        "            \"destination\": f\"`{destination_catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
-        "            \"success\": True,\n",
-        "            \"info\": None,\n",
-        "        }\n",
-        "    except Exception as err:\n",
-        "        return {\n",
-        "            \"source\": f\"`{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
-        "            \"destination\": f\"`{destination_catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
-        "            \"success\": False,\n",
-        "            \"info\": str(err),\n",
-        "        }\n",
-        "\n",
-        "\n",
-        "# Apply clone function to all tables in the source catalog\n",
-        "results = dx.from_tables(f\"{source_catalog}.*.*\").map(clone_table)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "727ecdf8",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "\n",
-        "%md\n",
-        "## Show cloning results\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c38f897b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "\n",
-        "results.display()"
-      ]
-    }
-  ],
-  "metadata": {
-    "application/vnd.databricks.v1+notebook": {
-      "environmentMetadata": {
-        "environment_version": "3"
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "308ee9ba",
+   "metadata": {},
+   "source": [
+    "# Clone a Catalog\n",
+    "This notebook uses [DiscoverX](https://github.com/databrickslabs/discoverx) to clone all schemas and tables from a source catalog into a destination catalog using Delta Lake `CLONE`.\n",
+    "\n",
+    "Specify the source and destination catalogs with the widgets below and run all cells.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5de86c07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "%pip install dbl-discoverx\n",
+    "dbutils.library.restartPython()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f289880",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "%md\n",
+    "## Configure source and destination catalogs\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0371d684",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Create widgets for user input\n",
+    "dbutils.widgets.text(\"1.source_catalog\", \"source_catalog\")\n",
+    "dbutils.widgets.text(\"2.destination_catalog\", \"destination_catalog\")\n",
+    "\n",
+    "source_catalog = dbutils.widgets.get(\"1.source_catalog\")\n",
+    "destination_catalog = dbutils.widgets.get(\"2.destination_catalog\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c3c753d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "%md\n",
+    "## Clone all tables using DiscoverX\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "387c79c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from discoverx import DX\n",
+    "\n",
+    "dx = DX()\n",
+    "\n",
+    "spark.sql(f\"CREATE CATALOG IF NOT EXISTS `{destination_catalog}`\")\n",
+    "\n",
+    "\n",
+    "def clone_table(table_info):\n",
+    "    \"\"\"Clone a single table into the destination catalog.\"\"\"\n",
+    "    spark.sql(f\"CREATE SCHEMA IF NOT EXISTS `{destination_catalog}`.`{table_info.schema}`\")\n",
+    "    try:\n",
+    "        spark.sql(\n",
+    "            f\"\"\"CREATE OR REPLACE TABLE `{destination_catalog}`.`{table_info.schema}`.`{table_info.table}` CLONE `{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`\"\"\"\n",
+    "        )\n",
+    "        return {\n",
+    "            \"source\": f\"`{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
+    "            \"destination\": f\"`{destination_catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
+    "            \"success\": True,\n",
+    "            \"info\": None,\n",
+    "        }\n",
+    "    except Exception as err:\n",
+    "        return {\n",
+    "            \"source\": f\"`{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
+    "            \"destination\": f\"`{destination_catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
+    "            \"success\": False,\n",
+    "            \"info\": str(err),\n",
+    "        }\n",
+    "\n",
+    "\n",
+    "# Apply clone function to all tables in the source catalog\n",
+    "results = dx.from_tables(f\"{source_catalog}.*.*\").map(clone_table)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "727ecdf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "%md\n",
+    "## Show cloning results\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c38f897b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "for item in results:\n",
+    "    print(json.dumps(item, indent=4))"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "environmentMetadata": {
+    "environment_version": "3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- use json.dumps to print DiscoverX results in clone_catalog
- use json.dumps to print DiscoverX results in change_owner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ee930504832995478b82e3cbc53f