### PR TITLE
Add logging and skip system objects

### DIFF
--- a/change_owner.ipynb
+++ b/change_owner.ipynb
@@ -65,11 +65,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "schemas_df = spark.sql(f\"SHOW SCHEMAS IN `{catalog}`\")\n",
     "for row in schemas_df.collect():\n",
     "    schema = row[0]\n",
-    "    spark.sql(f\"ALTER SCHEMA `{catalog}`.`{schema}` OWNER TO `{new_owner}`\")\n"
+    "    if schema.lower() in (\"information_schema\",):\n",
+    "        continue\n",
+    "    print(f\"Changing owner of object `{catalog}`.`{schema}` to `{new_owner}`\")\n",
+    "    spark.sql(f\"ALTER SCHEMA `{catalog}`.`{schema}` OWNER TO `{new_owner}`\")"
    ]
   },
   {
@@ -87,13 +89,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "from discoverx import DX\n",
     "\n",
     "dx = DX()\n",
     "\n",
     "def set_table_owner(tbl_info):\n",
+    "    if tbl_info.schema.lower() in (\"information_schema\",):\n",
+    "        return {\n",
+    "            \"table\": f\"`{tbl_info.catalog}`.`{tbl_info.schema}`.`{tbl_info.table}`\",\n",
+    "            \"success\": True,\n",
+    "            \"info\": \"skipped system schema\",\n",
+    "        }\n",
     "    try:\n",
+    "        print(f\"Changing owner of object `{tbl_info.catalog}`.`{tbl_info.schema}`.`{tbl_info.table}` to `{new_owner}`\")\n",
     "        spark.sql(\n",
     "            f\"ALTER TABLE `{tbl_info.catalog}`.`{tbl_info.schema}`.`{tbl_info.table}` OWNER TO `{new_owner}`\"\n",
     "        )\n",
@@ -109,7 +117,7 @@
     "            \"info\": str(err),\n",
     "        }\n",
     "\n",
-    "results = dx.from_tables(f\"{catalog}.*.*\").map(set_table_owner)\n"
+    "results = dx.from_tables(f\"{catalog}.*.*\").map(set_table_owner)"
    ]
   },
   {
@@ -127,16 +135,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "volume_df = spark.sql(f\"\"\"\n",
     "SELECT volume_schema, volume_name\n",
     "FROM system.information_schema.volumes\n",
     "WHERE volume_catalog = '{catalog}'\n",
     "\"\"\")\n",
     "for row in volume_df.collect():\n",
+    "    if row.volume_schema.lower() in (\"information_schema\",):\n",
+    "        continue\n",
+    "    print(f\"Changing owner of object `{catalog}`.`{row.volume_schema}`.`{row.volume_name}` to `{new_owner}`\")\n",
     "    spark.sql(\n",
     "        f\"ALTER VOLUME `{catalog}`.`{row.volume_schema}`.`{row.volume_name}` OWNER TO `{new_owner}`\"\n",
-    "    )\n"
+    "    )"
    ]
   },
   {
@@ -154,16 +164,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "func_df = spark.sql(f\"\"\"\n",
     "SELECT routine_schema, routine_name\n",
     "FROM system.information_schema.routines\n",
     "WHERE routine_catalog = '{catalog}'\n",
     "\"\"\")\n",
     "for row in func_df.collect():\n",
+    "    if row.routine_schema.lower() in (\"information_schema\",):\n",
+    "        continue\n",
+    "    print(f\"Changing owner of object `{catalog}`.`{row.routine_schema}`.`{row.routine_name}` to `{new_owner}`\")\n",
     "    spark.sql(\n",
     "        f\"ALTER FUNCTION `{catalog}`.`{row.routine_schema}`.`{row.routine_name}` OWNER TO `{new_owner}`\"\n",
-    "    )\n"
+    "    )"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add informational printouts when changing owner
- skip system objects such as `information_schema`

## Testing
- `python - <<'PY'
import nbformat
nbformat.read('change_owner.ipynb', as_version=4)
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6878f24ae6c4832982575e4daea6634c