### PR TITLE
Improve view detection when erasing old catalog

### DIFF
--- a/erase_old_catalog.ipynb
+++ b/erase_old_catalog.ipynb
@@ -72,9 +72,11 @@
     "for schema in schemas:\n",
     "    tables_df = spark.sql(f\"SHOW TABLES IN `{catalog}`.`{schema}`\")\n",
     "    for t in tables_df.collect():\n",
-    "        if t.tableType == 'VIEW':\n",
+    "        desc = spark.sql(f\"DESCRIBE EXTENDED `{catalog}`.`{schema}`.`{t.tableName}`\").collect()\n",
+    "        t_type = next((row.data_type for row in desc if str(row.col_name).upper() == 'TYPE'), '').upper().replace('_', ' ')\n",
+    "        if t_type == 'VIEW':\n",
     "            spark.sql(f\"DROP VIEW IF EXISTS `{catalog}`.`{schema}`.`{t.tableName}`\")\n",
-    "        elif t.tableType in ['MATERIALIZED VIEW', 'MATERIALIZED_VIEW']:\n",
+    "        elif t_type == 'MATERIALIZED VIEW':\n",
     "            spark.sql(f\"DROP MATERIALIZED VIEW IF EXISTS `{catalog}`.`{schema}`.`{t.tableName}`\")\n",
     "    spark.sql(f\"DROP SCHEMA IF EXISTS `{catalog}`.`{schema}`\")\n"
    ]


### PR DESCRIPTION
## Summary
- update *erase_old_catalog* notebook to rely on `DESCRIBE EXTENDED` when deciding whether an object is a View or Materialized View

## Testing
- `git diff-tree --numstat HEAD`

------
https://chatgpt.com/codex/tasks/task_e_6879344edd8c8329b2e95f2328e03eca