### PR TITLE
Add erase_schema notebook

### DIFF
--- a/erase_schema.ipynb
+++ b/erase_schema.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ca6e3d98",
+   "metadata": {},
+   "source": [
+    "# Erase Schema\n",
+    "This notebook drops all user-defined functions, tables, and views from a schema and then removes the schema. Provide the catalog and schema names with the widgets below and run all cells."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47dcd5a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+  "try:\n",
+  "    dbutils.widgets.text(\"1.catalog\", \"catalog\")\n",
+  "    dbutils.widgets.text(\"2.schema\", \"schema\")\n",
+  "    catalog = dbutils.widgets.get(\"1.catalog\")\n",
+  "    schema = dbutils.widgets.get(\"2.schema\")\n",
+  "except NameError:\n",
+  "    catalog = \"catalog\"\n",
+  "    schema = \"schema\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7dc56f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.sql(f\"USE CATALOG `{catalog}`\")\n",
+    "\n",
+    "skip_tables = set()\n",
+    "skip_views = set()\n",
+    "\n",
+    "# Drop functions sequentially\n",
+    "funcs_df = spark.sql(f\"SHOW USER FUNCTIONS IN `{catalog}`.`{schema}`\")\n",
+    "for f in funcs_df.collect():\n",
+    "    func_name = f[0]\n",
+    "    spark.sql(f\"DROP FUNCTION IF EXISTS `{catalog}`.`{schema}`.`{func_name}`\")\n",
+    "\n",
+    "# Drop tables sequentially\n",
+    "tables_df = spark.sql(f\"SHOW TABLES IN `{catalog}`.`{schema}`\")\n",
+    "for t in tables_df.collect():\n",
+    "    desc = spark.sql(f\"DESCRIBE EXTENDED `{catalog}`.`{schema}`.`{t.tableName}`\").collect()\n",
+    "    t_type = next((row.data_type for row in desc if str(row.col_name).upper() == \"TYPE\"), \"\").upper().replace(\"_\", \" \")\n",
+    "    if t_type == \"VIEW\":\n",
+    "        spark.sql(f\"DROP VIEW IF EXISTS `{catalog}`.`{schema}`.`{t.tableName}`\")\n",
+    "    elif t_type == \"MATERIALIZED_VIEW\":\n",
+    "        spark.sql(f\"DROP MATERIALIZED VIEW IF EXISTS `{catalog}`.`{schema}`.`{t.tableName}`\")\n",
+    "    else:\n",
+    "        spark.sql(f\"DROP TABLE IF EXISTS `{catalog}`.`{schema}`.`{t.tableName}`\")\n",
+    "\n",
+    "spark.sql(f\"DROP SCHEMA IF EXISTS `{catalog}`.`{schema}`\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aad5298c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Schema `{schema}` in catalog `{catalog}` cleanup complete.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "environmentMetadata": {
+    "environment_version": "3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `erase_schema.ipynb` to allow deleting all functions, tables, views and the schema itself for a specified catalog/schema combination
- update widgets in the notebook to use try/except fallback

## Testing
- `pip install nbformat -q`


------
https://chatgpt.com/codex/tasks/task_e_687a8517ba048329926d138b9bf3f9de