### PR TITLE
Update table size notebook for all schemas

### DIFF
--- a/catalog_table_sizes.ipynb
+++ b/catalog_table_sizes.ipynb
@@ -14,9 +14,9 @@
    },
    "source": [
     "# Catalog Table Sizes\n",
-    "This notebook lists the total size of every table in a selected catalog and schema using [DiscoverX](https://github.com/databrickslabs/discoverx).\n",
+    "This notebook lists the total size of every table across all schemas in a selected catalog using [DiscoverX](https://github.com/databrickslabs/discoverx).\n",
     "\n",
-    "Use the widgets below to select a catalog and schema, then run the remaining cells."
+    "Use the widget below to select a catalog, then run the remaining cells."
    ]
   },
   {
@@ -60,7 +60,7 @@
    },
    "outputs": [],
    "source": [
-    "# Create widgets for catalog and schema\n",
+    "# Create widgets for catalog\n",
     "catalogs = [row.catalog for row in spark.sql(\"SHOW CATALOGS\").collect()]\n",
     "catalogs.append(\"None Selected\")\n",
     "dbutils.widgets.combobox(\"1.catalog\", \"None Selected\", catalogs)\n",
@@ -116,7 +116,7 @@
     "    print(f'{tbl.catalog}.{tbl.schema}.{tbl.table}: {readable}')\n",
     "    return {\"table\": f\"{tbl.catalog}.{tbl.schema}.{tbl.table}\", \"size\": readable}\n",
     "\n",
-    "results = dx.from_tables(f\"{catalog}.{schema}.*\").map(table_size)\n",
+    "results = dx.from_tables(f\"{catalog}.*.*\").map(table_size)\n",
     "\n",
     "import json\n",
     "for r in results:\n",


### PR DESCRIPTION
## Summary
- update description in catalog_table_sizes notebook
- remove mention of schema widget
- calculate table sizes for every schema in the selected catalog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68840a2005488329a366d7b5600428ac