### PR TITLE
Display table sizes in table

### DIFF
--- a/catalog_table_sizes.ipynb
+++ b/catalog_table_sizes.ipynb
@@ -119,15 +119,11 @@
     "    qname = f\"`{tbl.catalog}`.`{tbl.schema}`.`{tbl.table}`\"\n",
     "    df = spark.sql(f\"DESCRIBE DETAIL {qname}\")\n",
     "    size = df.select('sizeInBytes').collect()[0][0]\n",
-    "    readable = human_size(size)\n",
-    "    print(f'{tbl.catalog}.{tbl.schema}.{tbl.table}: {readable}')\n",
-    "    return {\"table\": f\"{tbl.catalog}.{tbl.schema}.{tbl.table}\", \"size\": readable}\n",
+    "    return {\"table\": f\"{tbl.catalog}.{tbl.schema}.{tbl.table}\", \"size\": human_size(size)}\n",
     "\n",
     "results = dx.from_tables(f\"{catalog}.*.*\").map(table_size)\n",
-    "\n",
-    "# import json\n",
-    "# for r in results:\n",
-    "#     print(json.dumps(r, indent=4))"
+    "df = spark.createDataFrame(results)\n",
+    "display(df)\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- tidy up table size logic
- collect results into a Spark DataFrame
- display the data at the end of the notebook

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68840fd9974083298b2db15ff63d8bb5