### PR TITLE
Enable multi-catalog selection for table size report

### DIFF
--- a/catalog_table_sizes.ipynb
+++ b/catalog_table_sizes.ipynb
@@ -16,7 +16,7 @@
     "# Catalog Table Sizes\n",
     "This notebook lists the total size of every table across all schemas in a selected catalog using [DiscoverX](https://github.com/databrickslabs/discoverx).\n",
     "\n",
-    "Use the widget below to select a catalog, then run the remaining cells."
+    "Use the widget below to select one or more catalogs, then run the remaining cells."
    ]
   },
   {
@@ -60,10 +60,9 @@
    },
    "outputs": [],
    "source": [
-    "# Create widgets for catalog\n",
+    "# Create widgets for catalogs\n",
     "catalogs = [row.catalog for row in spark.sql(\"SHOW CATALOGS\").collect()]\n",
-    "catalogs.append(\"None Selected\")\n",
-    "dbutils.widgets.combobox(\"1.catalog\", \"None Selected\", catalogs)"
+    "dbutils.widgets.multiselect(\"1.catalogs\", \"\", catalogs)"
    ]
   },
   {
@@ -84,7 +83,7 @@
    },
    "outputs": [],
    "source": [
-    "catalog = dbutils.widgets.get(\"1.catalog\")"
+    "catalog_list = [c for c in dbutils.widgets.get(\"1.catalogs\").split(',') if c]"
    ]
   },
   {
@@ -120,12 +119,14 @@
     "    df = spark.sql(f\"DESCRIBE DETAIL {qname}\")\n",
     "    size = df.select('sizeInBytes').collect()[0][0]\n",
     "    return {\n",
-    "        \"table\": f\"{tbl.catalog}.{tbl.schema}.{tbl.table}\",\n",
-    "        \"size\": size,\n",
-    "        \"size_human\": human_size(size)\n",
+    "        'table': f\"{tbl.catalog}.{tbl.schema}.{tbl.table}\",\n",
+    "        'size': size,\n",
+    "        'size_human': human_size(size)\n",
     "    }\n",
     "\n",
-    "results = dx.from_tables(f\"{catalog}.*.*\").map(table_size)\n",
+    "results = []\n",
+    "for cat in catalog_list:\n",
+    "    results.extend(dx.from_tables(f'{cat}.*.*').map(table_size))\n",
     "df = spark.createDataFrame(results)\n",
     "display(df)\n"
    ]


### PR DESCRIPTION
## Summary
- allow choosing multiple catalogs
- aggregate table sizes across all selected catalogs

## Testing
- `jupyter nbconvert --to markdown catalog_table_sizes.ipynb --stdout`

------
https://chatgpt.com/codex/tasks/task_e_6887d87120b48329bcfa9580234b0020