### PR TITLE
Add backup catalog notebook

### DIFF
--- a/backup_catalog.ipynb
+++ b/backup_catalog.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "308ee9ba",
+   "metadata": {},
+   "source": [
+    "# Backup a Catalog\n",
+    "This notebook uses [DiscoverX](https://github.com/databrickslabs/discoverx) to clone all schemas and tables from a source catalog into a destination catalog using Delta Lake `CLONE`.\n",
+    "After cloning, it removes any tables or schemas in the destination that no longer exist in the source.\n",
+    "\n",
+    "Specify the source and destination catalogs with the widgets below and run all cells.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5de86c07",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "%pip install dbl-discoverx\n",
+    "dbutils.library.restartPython()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f289880",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "%md\n",
+    "## Configure source and destination catalogs\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0371d684",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Create widgets for user input\n",
+    "dbutils.widgets.text(\"1.source_catalog\", \"source_catalog\")\n",
+    "dbutils.widgets.text(\"2.destination_catalog\", \"destination_catalog\")\n",
+    "\n",
+    "source_catalog = dbutils.widgets.get(\"1.source_catalog\")\n",
+    "destination_catalog = dbutils.widgets.get(\"2.destination_catalog\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c3c753d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "%md\n",
+    "## Clone all tables using DiscoverX\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "387c79c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from discoverx import DX\n",
+    "\n",
+    "dx = DX()\n",
+    "\n",
+    "spark.sql(f\"CREATE CATALOG IF NOT EXISTS `{destination_catalog}`\")\n",
+    "\n",
+    "\n",
+    "def clone_table(table_info):\n",
+    "    \"\"\"Clone a single table into the destination catalog.\"\"\"\n",
+    "    spark.sql(f\"CREATE SCHEMA IF NOT EXISTS `{destination_catalog}`.`{table_info.schema}`\")\n",
+    "    try:\n",
+    "        spark.sql(\n",
+    "            f\"\"\"CREATE OR REPLACE TABLE `{destination_catalog}`.`{table_info.schema}`.`{table_info.table}` CLONE `{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`\"\"\"\n",
+    "        )\n",
+    "        return {\n",
+    "            \"source\": f\"`{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
+    "            \"destination\": f\"`{destination_catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
+    "            \"success\": True,\n",
+    "            \"info\": None,\n",
+    "        }\n",
+    "    except Exception as err:\n",
+    "        return {\n",
+    "            \"source\": f\"`{table_info.catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
+    "            \"destination\": f\"`{destination_catalog}`.`{table_info.schema}`.`{table_info.table}`\",\n",
+    "            \"success\": False,\n",
+    "            \"info\": str(err),\n",
+    "        }\n",
+    "\n",
+    "\n",
+    "# Apply clone function to all tables in the source catalog\n",
+    "results = dx.from_tables(f\"{source_catalog}.*.*\").map(clone_table)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "727ecdf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "%md\n",
+    "## Show cloning results\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c38f897b",
+   "metadata": {},
+  "outputs": [],
+  "source": [
+   "import json\n",
+   "for item in results:\n",
+   "    print(json.dumps(item, indent=4))"
+  ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1f5226d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "%md\n",
+    "## Remove stale tables from the destination catalog\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c81d9c9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Determine tables present only in the destination catalog\n",
+    "source_df = spark.sql(f\"""\n",
+    "    SELECT table_schema, table_name\n",
+    "    FROM `{source_catalog}`.information_schema.tables\n",
+    "    WHERE table_schema NOT IN ('information_schema')\n",
+    """\n",
+    ")\n",
+    "dest_df = spark.sql(f\"""\n",
+    "    SELECT table_schema, table_name\n",
+    "    FROM `{destination_catalog}`.information_schema.tables\n",
+    "    WHERE table_schema NOT IN ('information_schema')\n",
+    """\n",
+    ")\n",
+    "source_tables = {(r.table_schema, r.table_name) for r in source_df.collect()}\n",
+    "dest_tables = {(r.table_schema, r.table_name) for r in dest_df.collect()}\n",
+    "\n",
+    "obsolete_tables = dest_tables - source_tables\n",
+    "for schema, table in sorted(obsolete_tables):\n",
+    "    spark.sql(f\"DROP TABLE IF EXISTS `{destination_catalog}`.`{schema}`.`{table}`\")\n",
+    "    print(f'Dropped `{destination_catalog}`.`{schema}`.`{table}`')\n",
+    "\n",
+    "# Drop any empty schemas that remain\n",
+    "schema_df = spark.sql(f'SHOW SCHEMAS IN `{destination_catalog}`')\n",
+    "for row in schema_df.collect():\n",
+    "    schema = row.schemaName if hasattr(row, 'schemaName') else row[0]\n",
+    "    if schema == 'information_schema':\n",
+    "        continue\n",
+    "    if not spark.sql(f'SHOW TABLES IN `{destination_catalog}`.`{schema}`').collect():\n",
+    "        spark.sql(f'DROP SCHEMA IF EXISTS `{destination_catalog}`.`{schema}`')\n",
+    "        print(f'Dropped schema `{destination_catalog}`.`{schema}`')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "environmentMetadata": {
+    "environment_version": "3"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create a `backup_catalog.ipynb` notebook derived from the clone catalog example
- include a final cell that removes stale tables and schemas from the destination catalog
- remove the standalone `cleanup_extra_tables.py` script

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(no Python files to compile)*

------
https://chatgpt.com/codex/tasks/task_e_6888e73f22108329819e940281a14b1b