### PR TITLE
Use dropdown widgets in backup catalog notebook

### DIFF
--- a/backup_catalog.ipynb
+++ b/backup_catalog.ipynb
@@ -78,9 +78,10 @@
    "outputs": [],
    "source": [
     "\n",
-    "# Create widgets for user input\n",
-    "dbutils.widgets.text(\"1.source_catalog\", \"source_catalog\")\n",
-    "dbutils.widgets.text(\"2.destination_catalog\", \"destination_catalog\")\n",
+    "# Create widgets for user input using drop-downs populated from existing catalogs\n",
+    "catalogs = [row.catalog for row in spark.sql(\"SHOW CATALOGS\").collect()]\n",
+    "dbutils.widgets.combobox(\"1.source_catalog\", catalogs[0], catalogs, label=\"Source Catalog\")\n",
+    "dbutils.widgets.combobox(\"2.destination_catalog\", catalogs[0], catalogs, label=\"Destination Catalog\")\n",
     "\n",
     "source_catalog = dbutils.widgets.get(\"1.source_catalog\")\n",
     "destination_catalog = dbutils.widgets.get(\"2.destination_catalog\")\n"


### PR DESCRIPTION
## Summary
- update notebook to collect available catalogs and populate combo box widgets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a28c0ba088329a2e1b2ce00c8fe46