### PR TITLE
Add sanity checks for backup catalog

### DIFF
--- a/backup_catalog.ipynb
+++ b/backup_catalog.ipynb
@@ -84,7 +84,14 @@
     "dbutils.widgets.combobox(\"2.destination_catalog\", catalogs[0], catalogs, label=\"Destination Catalog\")\n",
     "\n",
     "source_catalog = dbutils.widgets.get(\"1.source_catalog\")\n",
-    "destination_catalog = dbutils.widgets.get(\"2.destination_catalog\")\n"
+    "destination_catalog = dbutils.widgets.get(\"2.destination_catalog\")\n",
+    "\n",
+    "allowed_catalogs = {'dev', 'staging', 'prod'}\n",
+    "if source_catalog not in allowed_catalogs:\n",
+    "    raise ValueError(f'Source catalog must be one of {sorted(allowed_catalogs)}')\n",
+    "expected_dest = f'{source_catalog}_backup'\n",
+    "if destination_catalog != expected_dest:\n",
+    "    raise ValueError(f'Destination catalog must be {expected_dest}')\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- enforce catalog naming scheme in `backup_catalog.ipynb`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a2b1000908329aec024ac5d985ce3