### PR TITLE
Improve backup catalog widgets

### DIFF
--- a/backup_catalog.ipynb
+++ b/backup_catalog.ipynb
@@ -80,12 +80,51 @@
     "\n",
     "# Create widgets for user input using drop-downs populated from existing catalogs\n",
     "catalogs = ['None Selected'] + [row.catalog for row in spark.sql(\"SHOW CATALOGS\").collect()]\n",
-    "dbutils.widgets.combobox(\"1.source_catalog\", \"None Selected\", catalogs, label=\"Source Catalog\")\n",
-    "dbutils.widgets.combobox(\"2.destination_catalog\", \"None Selected\", catalogs, label=\"Destination Catalog\")\n",
-    "\n",
+    "dbutils.widgets.combobox(\"1.source_catalog\", \"None Selected\", catalogs, label=\"1. Source Catalog\")\n",
+    "dbutils.widgets.combobox(\"2.destination_catalog\", \"None Selected\", catalogs, label=\"2. Destination Catalog\")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "41139b85-2447-4fe9-9e1a-1715e890cf0a",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
     "source_catalog = dbutils.widgets.get(\"1.source_catalog\")\n",
-    "destination_catalog = dbutils.widgets.get(\"2.destination_catalog\")\n",
-    "\n",
+    "destination_catalog = dbutils.widgets.get(\"2.destination_catalog\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "41139b85-2447-4fe9-9e1a-1715e890cf0a",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
     "allowed_catalogs = {'dev', 'staging', 'prod'}\n",
     "if source_catalog not in allowed_catalogs:\n",
     "    raise ValueError(f'Source catalog must be one of {sorted(allowed_catalogs)}')\n",


### PR DESCRIPTION
## Summary
- add numeric prefixes to widget labels
- split widget logic across three cells for clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a312f2ed483298f52afe901be098b