### PR TITLE
Add permission migration step to backup notebook

### DIFF
--- a/backup_catalog.ipynb
+++ b/backup_catalog.ipynb
@@ -255,6 +255,75 @@
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
      "inputWidgets": {},
+     "nuid": "auto-generated-perms-md",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## Migrate Schema and Table Permissions\n",
+    "Copy permissions from the source catalog to the destination."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "collapsed": false,
+     "inputWidgets": {},
+     "nuid": "auto-generated-perms-code",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "schema_query = f\"\"\"\n",
+    "SELECT schema_name, grantee, privilege_type\n",
+    "FROM system.information_schema.schema_privileges\n",
+    "WHERE catalog_name = '{source_catalog}'\n",
+    "\"\"\"\n",
+    "\n",
+    "table_query = f\"\"\"\n",
+    "SELECT table_schema, table_name, grantee, privilege_type\n",
+    "FROM system.information_schema.table_privileges\n",
+    "WHERE table_catalog = '{source_catalog}'\n",
+    "\"\"\"\n",
+    "\n",
+    "schema_df = spark.sql(schema_query)\n",
+    "table_df = spark.sql(table_query)\n",
+    "\n",
+    "grant_cmds = []\n",
+    "for row in schema_df.collect():\n",
+    "    if row.schema_name.lower() == 'information_schema':\n",
+    "        continue\n",
+    "    object_identifier = f\"`{destination_catalog}`.`{row.schema_name}`\"\n",
+    "    grant_cmds.append(f\"GRANT {row.privilege_type} ON SCHEMA {object_identifier} TO `{row.grantee}`;\")\n",
+    "\n",
+    "for row in table_df.collect():\n",
+    "    if row.table_schema.lower() == 'information_schema':\n",
+    "        continue\n",
+    "    object_identifier = f\"`{destination_catalog}`.`{row.table_schema}`.`{row.table_name}`\"\n",
+    "    grant_cmds.append(f\"GRANT {row.privilege_type} ON TABLE {object_identifier} TO `{row.grantee}`;\")\n",
+    "\n",
+    "for cmd in grant_cmds:\n",
+    "    print(cmd)\n",
+    "    spark.sql(cmd)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
      "nuid": "131fa9cf-efcd-49bb-a7df-e59750085b76",
      "showTitle": false,
      "tableResultSettingsMap": {},


### PR DESCRIPTION
## Summary
- add step to migrate schema and table permissions in `backup_catalog.ipynb`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a4a8a57ec83298b8704b9bbe121e8