### PR TITLE
Add edsm to allowed catalogs

### DIFF
--- a/backup_catalog.ipynb
+++ b/backup_catalog.ipynb
@@ -124,7 +124,7 @@
       },
       "outputs": [],
       "source": [
-        "allowed_catalogs = {'dev', 'staging', 'prod'}\n",
+        "allowed_catalogs = {'dev', 'staging', 'prod', 'edsm'}\n",
         "if source_catalog not in allowed_catalogs:\n",
         "    raise ValueError(f'Source catalog must be one of {sorted(allowed_catalogs)}')\n",
         "expected_dest = f'{source_catalog}_backup'\n",


### PR DESCRIPTION
## Summary
- allow edsm catalog as backup source

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7638db1c8329a0ec36462ddaa9e6